### PR TITLE
Tnt 498

### DIFF
--- a/src/search/atoms.ts
+++ b/src/search/atoms.ts
@@ -86,7 +86,6 @@ const performAddressSearch = async (
   return null;
 };
 
-
 const searchQueryEffect = atomEffect((get, set) => {
   const searchQuery = get(searchQueryAtom);
   const store = getDefaultStore();

--- a/src/search/atoms.ts
+++ b/src/search/atoms.ts
@@ -48,6 +48,8 @@ export const searchPendingAtom = atom<boolean>(false);
 export const placeNamePageAtom = atom<number>(1);
 export const displaySearchResultsAtom = atom<boolean>(true);
 
+let latestSearchRequestId = 0;
+
 const searchCoordinatesEffect = atomEffect((get, set) => {
   const coords = get(searchCoordinatesAtom);
   if (coords === null) {
@@ -83,9 +85,12 @@ const performAddressSearch = async (
   }
   return null;
 };
+
+
 const searchQueryEffect = atomEffect((get, set) => {
   const searchQuery = get(searchQueryAtom);
   const store = getDefaultStore();
+  const requestId = ++latestSearchRequestId;
 
   if (searchQuery) {
     setUrlParameter('sok', searchQuery);
@@ -132,6 +137,10 @@ const searchQueryEffect = atomEffect((get, set) => {
   };
   fetchData()
     .then((r) => {
+      if (requestId !== latestSearchRequestId) {
+        return;
+      }
+
       const [addresResult, placeResult, roadsResult, propertiesResult] = r;
       if (addresResult?.adresser) {
         if (addresResult.adresser.length === 1) {
@@ -167,7 +176,9 @@ const searchQueryEffect = atomEffect((get, set) => {
       set(searchPendingAtom, false);
     })
     .finally(() => {
-      set(searchPendingAtom, false);
+      if (requestId === latestSearchRequestId) {
+        set(searchPendingAtom, false);
+      }
     });
 });
 

--- a/src/search/searchApi.ts
+++ b/src/search/searchApi.ts
@@ -36,7 +36,6 @@ const trackApiError = (
 const normalizeAddressQuery = (query: string): string =>
   query.replace(/\s+/g, ' ').trim();
 
-
 export const getAddresses = async (
   query: string,
 ): Promise<AddressApiResponse> => {

--- a/src/search/searchApi.ts
+++ b/src/search/searchApi.ts
@@ -33,9 +33,9 @@ const trackApiError = (
   }
 };
 
-const normalizeAddressQuery = (query: string): string => {
-  return query.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
-}
+const normalizeAddressQuery = (query: string): string =>
+  query.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
+
 
 export const getAddresses = async (
   query: string,

--- a/src/search/searchApi.ts
+++ b/src/search/searchApi.ts
@@ -34,7 +34,7 @@ const trackApiError = (
 };
 
 const normalizeAddressQuery = (query: string): string =>
-  query.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
+  query.replace(/\s+/g, ' ').trim();
 
 
 export const getAddresses = async (
@@ -45,7 +45,7 @@ export const getAddresses = async (
   try {
     const normalizedQuery = normalizeAddressQuery(query);
     const encodedQuery = encodeURIComponent(normalizedQuery);
-    const url = `${env.geoNorgeApiBaseUrl}/adresser/v1/sok?sok=${encodedQuery}&treffPerSide=100`;
+    url = `${env.geoNorgeApiBaseUrl}/adresser/v1/sok?sok=${encodedQuery}&treffPerSide=100`;
     const res = await fetch(url);
     httpStatus = res.status;
 

--- a/src/search/searchApi.ts
+++ b/src/search/searchApi.ts
@@ -33,14 +33,19 @@ const trackApiError = (
   }
 };
 
+const normalizeAddressQuery = (query: string): string => {
+  return query.replace(/,/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
 export const getAddresses = async (
   query: string,
 ): Promise<AddressApiResponse> => {
   let url;
   let httpStatus;
   try {
-    const encodedQuery = encodeURIComponent(query);
-    const url = `${env.geoNorgeApiBaseUrl}/adresser/v1/sok?sok=${encodedQuery}&treffPerSide=100&fuzzy=true`;
+    const normalizedQuery = normalizeAddressQuery(query);
+    const encodedQuery = encodeURIComponent(normalizedQuery);
+    const url = `${env.geoNorgeApiBaseUrl}/adresser/v1/sok?sok=${encodedQuery}&treffPerSide=100`;
     const res = await fetch(url);
     httpStatus = res.status;
 


### PR DESCRIPTION
Tror at hovedgrunnen til alle tilbakemeldinger om søket kan være at søket kunne vise gamle resultater etterpå, slik at det mest konkrete treffet ikke alltid kom øverst. Derfor ble det mye rot i resultatlisten. Så  jeg har gjort resultaten litt mer stabil her forhåpentligvis. 

Har også gjort at det går an å søke med komma i adressesøk (måtte normaliseres for å gi treff)
fuzzy ga også en del irrelevante forslag så fjernet fuzzy search fra adressesøk

